### PR TITLE
RH-86172 Export_USD missing devinfo.cpp on Mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,16 @@
 *.pdb
 *.pdb.bak
 
+# Xcode Project
+**/*.xcodeproj/xcuserdata/
+**/*.xcworkspace/xcuserdata/
+**/.swiftpm/xcode/xcuserdata/
+**/*.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+**/*.xcworkspace/xcshareddata/*.xccheckout
+**/*.xcworkspace/xcshareddata/*.xcscmblueprint
+**/*.playground/**/timeline.xctimeline
+.idea/
+
 # MacOS cruft
 .DS_Store
 

--- a/export_USD/export_USD.xcodeproj/project.pbxproj
+++ b/export_USD/export_USD.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1A6FA13D2D6DA22800A94307 /* devinfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A6FA13C2D6DA22800A94307 /* devinfo.cpp */; };
 		223BC30C29D22B390090D5E8 /* ExportUSDPlugIn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 223BC30A29D22B390090D5E8 /* ExportUSDPlugIn.cpp */; };
 		223BC30D29D22B390090D5E8 /* write_usd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 223BC30B29D22B390090D5E8 /* write_usd.cpp */; };
 		22C600CA29D23121002FBBF0 /* OpenNURBS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 22C600C929D23121002FBBF0 /* OpenNURBS.framework */; };
@@ -18,6 +19,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1A6FA13C2D6DA22800A94307 /* devinfo.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = devinfo.cpp; path = ../../devinfo.cpp; sourceTree = "<group>"; };
 		220221EB29D22A31005357DE /* export_USD.rhp */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = export_USD.rhp; sourceTree = BUILT_PRODUCTS_DIR; };
 		223BC30829D22B280090D5E8 /* stdafx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stdafx.h; sourceTree = "<group>"; };
 		223BC30929D22B280090D5E8 /* ExportUSDPlugIn.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExportUSDPlugIn.h; sourceTree = "<group>"; };
@@ -94,6 +96,7 @@
 		223BC30729D22AD90090D5E8 /* Source Files */ = {
 			isa = PBXGroup;
 			children = (
+				1A6FA13C2D6DA22800A94307 /* devinfo.cpp */,
 				997ED8B929D3DC4D00DAE8F8 /* ON_Helpers.cpp */,
 				997ED8B829D3DC4D00DAE8F8 /* UsdShared.cpp */,
 				223BC30A29D22B390090D5E8 /* ExportUSDPlugIn.cpp */,
@@ -180,6 +183,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1A6FA13D2D6DA22800A94307 /* devinfo.cpp in Sources */,
 				997ED8BC29D3DC4D00DAE8F8 /* UsdShared.cpp in Sources */,
 				223BC30D29D22B390090D5E8 /* write_usd.cpp in Sources */,
 				997ED8BD29D3DC4D00DAE8F8 /* ON_Helpers.cpp in Sources */,


### PR DESCRIPTION
- Updated XCode Project to include devinfo.cpp as all other Plugins do.
- Updated the .gitignore